### PR TITLE
Add METL model

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 <div id="features" class="section">
     <h2>Features</h2>
     <center>
-    <a href="https://www.biorxiv.org/content/10.1101/2024.05.24.595648v2"><img src="https://img.shields.io/badge/Paper-bioRxiv-green" style="max-width: 100%;"></a>
+    <a href="https://doi.org/10.1101/2024.05.24.595648"><img src="https://img.shields.io/badge/Paper-bioRxiv-green" style="max-width: 100%;"></a>
     <a href="https://huggingface.co/SaProtHub"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-red?label=SaprotHub" style="max-width: 100%;"></a>
     <a href="https://colab.research.google.com/github/westlake-repl/SaprotHub/blob/main/colab/SaprotHub.ipynb"><img src="templates/figures/colab-badge.svg" style="max-width: 100%;"></a>
     <a href="https://cbirt.net/no-coding-required-saprothub-brings-protein-modeling-to-every-biologist/" alt="blog"><img src="https://img.shields.io/badge/Blog-Medium-purple" /></a> 

--- a/index.html
+++ b/index.html
@@ -77,6 +77,12 @@
             <a href="https://huggingface.co/T5Hub">T5Hub</a>
         </div>
 
+        <div class="model">
+            <h2>METL</h2>
+            <p>Biophysics-based protein language models for protein engineering</p>
+            <a href="https://github.com/gitter-lab/metl?tab=readme-ov-file#mutational-effect-transfer-learning">METL Colab and Hub</a>
+        </div>
+
     </div>
 </div>
 
@@ -188,7 +194,7 @@
         </div>
         <div class="member">
             <span class="name">Philip A. Romero</span><br>
-            <span class="school">University of Wisconsin-Madison</span>
+            <span class="school">Duke University</span>
         </div>
         <div class="member">
             <span class="name">Jianyi Yang</span><br>


### PR DESCRIPTION
This pull request serves to start a discussion about how to link to the METL Colab notebooks and Hugging Face demo. We have multiple notebooks, so our proposal is to have all of them at the top of our GitHub repo and link to everything from there. The METL repo pull request https://github.com/gitter-lab/metl/pull/5 is better organizing that.

I'm also talking to my group ask will add another commit here if any of them who developed these resources want to join OPMC as regular authors.